### PR TITLE
Adding custom struct handlers in documentation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Forked from & all credit to [Savaki](https://github.com/savaki)
 
-[![GoDoc](https://godoc.org/github.com/frednomoon/swag?status.svg)](https://godoc.org/github.com/frednomoon/swag)
+[![GoDoc](https://godoc.org/github.com/music-tribe/swag?status.svg)](https://godoc.org/github.com/music-tribe/swag)
 
 ```swag``` is a lightweight library to generate swagger json for Go projects.  
  
@@ -16,7 +16,7 @@ No code generation, no framework constraints, just a simple swagger definition.
 ## Installation
 
 ```bash
-go get github.com/frednomoon/swag
+go get github.com/music-tribe/swag
 ```
 
 
@@ -51,7 +51,7 @@ allPets := endpoint.New("get", "/pet", "Return all the pets",
 ) 
 ```
 
-Refer to the [godoc](https://godoc.org/github.com/frednomoon/swag/endpoint) for a list of all the endpoint options
+Refer to the [godoc](https://godoc.org/github.com/music-tribe/swag/endpoint) for a list of all the endpoint options
 
 ### Walk
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # swag
 
-[![GoDoc](https://godoc.org/github.com/savaki/swag?status.svg)](https://godoc.org/github.com/savaki/swag)
-[![Build Status](https://travis-ci.org/savaki/swag.svg?branch=master)](https://travis-ci.org/savaki/swag)
+[![GoDoc](https://godoc.org/github.com/frednomoon/swag?status.svg)](https://godoc.org/github.com/frednomoon/swag)
+[![Build Status](https://travis-ci.org/frednomoon/swag.svg?branch=master)](https://travis-ci.org/frednomoon/swag)
 
 ```swag``` is a lightweight library to generate swagger json for Go projects.  
  
@@ -13,7 +13,7 @@ No code generation, no framework constraints, just a simple swagger definition.
 ## Installation
 
 ```bash
-go get github.com/savaki/swag
+go get github.com/frednomoon/swag
 ```
 
 
@@ -48,7 +48,7 @@ allPets := endpoint.New("get", "/pet", "Return all the pets",
 ) 
 ```
 
-Refer to the [godoc](https://godoc.org/github.com/savaki/swag/endpoint) for a list of all the endpoint options
+Refer to the [godoc](https://godoc.org/github.com/frednomoon/swag/endpoint) for a list of all the endpoint options
 
 ### Walk
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+
+
 # swag
 
+Forked from & all credit to [Savaki](https://github.com/savaki)
+
 [![GoDoc](https://godoc.org/github.com/frednomoon/swag?status.svg)](https://godoc.org/github.com/frednomoon/swag)
-[![Build Status](https://travis-ci.org/frednomoon/swag.svg?branch=master)](https://travis-ci.org/frednomoon/swag)
 
 ```swag``` is a lightweight library to generate swagger json for Go projects.  
  

--- a/builder.go
+++ b/builder.go
@@ -14,7 +14,7 @@
 //
 package swag
 
-import "github.com/frednomoon/swag/swagger"
+import "github.com/music-tribe/swag/swagger"
 
 // Builder uses the builder pattern to generate a swagger definition
 type Builder struct {

--- a/builder.go
+++ b/builder.go
@@ -14,7 +14,7 @@
 //
 package swag
 
-import "github.com/savaki/swag/swagger"
+import "github.com/frednomoon/swag/swagger"
 
 // Builder uses the builder pattern to generate a swagger definition
 type Builder struct {

--- a/builder_test.go
+++ b/builder_test.go
@@ -17,8 +17,8 @@ package swag_test
 import (
 	"testing"
 
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/swagger"
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -17,8 +17,8 @@ package swag_test
 import (
 	"testing"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/endpoint/builder.go
+++ b/endpoint/builder.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag/swagger"
 )
 
 // Builder uses the builder pattern to generate swagger endpoint definitions

--- a/endpoint/builder.go
+++ b/endpoint/builder.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/savaki/swag/swagger"
+	"github.com/frednomoon/swag/swagger"
 )
 
 // Builder uses the builder pattern to generate swagger endpoint definitions

--- a/endpoint/builder_test.go
+++ b/endpoint/builder_test.go
@@ -21,9 +21,9 @@ import (
 
 	"reflect"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/endpoint"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/endpoint"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/endpoint/builder_test.go
+++ b/endpoint/builder_test.go
@@ -21,9 +21,9 @@ import (
 
 	"reflect"
 
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/endpoint"
-	"github.com/savaki/swag/swagger"
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/endpoint"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/builtin/main.go
+++ b/examples/builtin/main.go
@@ -18,9 +18,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/endpoint"
-	"github.com/savaki/swag/swagger"
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/endpoint"
+	"github.com/frednomoon/swag/swagger"
 )
 
 func handle(w http.ResponseWriter, req *http.Request) {

--- a/examples/builtin/main.go
+++ b/examples/builtin/main.go
@@ -18,9 +18,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/endpoint"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/endpoint"
+	"github.com/music-tribe/swag/swagger"
 )
 
 func handle(w http.ResponseWriter, req *http.Request) {

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -18,9 +18,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/endpoint"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/endpoint"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/labstack/echo"
 )
 

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -18,10 +18,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/endpoint"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/labstack/echo"
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/endpoint"
-	"github.com/savaki/swag/swagger"
 )
 
 func handle(c echo.Context) error {

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -18,9 +18,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/endpoint"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/endpoint"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/gin-gonic/gin"
 )
 

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -18,10 +18,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/endpoint"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/gin-gonic/gin"
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/endpoint"
-	"github.com/savaki/swag/swagger"
 )
 
 func handle(c *gin.Context) {

--- a/examples/gorilla/main.go
+++ b/examples/gorilla/main.go
@@ -18,9 +18,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/endpoint"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/endpoint"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/gorilla/mux"
 )
 

--- a/examples/gorilla/main.go
+++ b/examples/gorilla/main.go
@@ -18,10 +18,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/endpoint"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/gorilla/mux"
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/endpoint"
-	"github.com/savaki/swag/swagger"
 )
 
 func handle(w http.ResponseWriter, _ *http.Request) {

--- a/examples/httprouter/main.go
+++ b/examples/httprouter/main.go
@@ -18,10 +18,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/frednomoon/swag"
+	"github.com/frednomoon/swag/endpoint"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/julienschmidt/httprouter"
-	"github.com/savaki/swag"
-	"github.com/savaki/swag/endpoint"
-	"github.com/savaki/swag/swagger"
 )
 
 func handle(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/examples/httprouter/main.go
+++ b/examples/httprouter/main.go
@@ -18,9 +18,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/frednomoon/swag"
-	"github.com/frednomoon/swag/endpoint"
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag"
+	"github.com/music-tribe/swag/endpoint"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/swagger/api_test.go
+++ b/swagger/api_test.go
@@ -23,7 +23,7 @@ import (
 
 	"path/filepath"
 
-	"github.com/frednomoon/swag/swagger"
+	"github.com/music-tribe/swag/swagger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/swagger/api_test.go
+++ b/swagger/api_test.go
@@ -23,7 +23,7 @@ import (
 
 	"path/filepath"
 
-	"github.com/savaki/swag/swagger"
+	"github.com/frednomoon/swag/swagger"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/swagger/reflect.go
+++ b/swagger/reflect.go
@@ -17,6 +17,7 @@ package swagger
 import (
 	"reflect"
 	"strings"
+	"time"
 )
 
 func inspect(t reflect.Type, jsonTag string) Property {
@@ -33,6 +34,27 @@ func inspect(t reflect.Type, jsonTag string) Property {
 		p.GoType = reflect.TypeOf("string")
 		p.Type = "string"
 		p.Format = "uuid"
+		return p
+	}
+
+	if t.String() == "*bool" {
+		p.GoType = reflect.TypeOf("bool")
+		p.Type = "boolean"
+		return p
+	}
+
+	if t.String() == "time.Time" {
+		p.GoType = reflect.TypeOf("string")
+		p.Example = time.Now().UTC().Format(time.RFC3339)
+		p.Type = "string"
+		p.Format = "date"
+		return p
+	}
+
+	if t.String() == "json.RawMessage" {
+		p.GoType = reflect.TypeOf("struct")
+		p.Type = "object"
+		p.Format = "json"
 		return p
 	}
 

--- a/swagger/reflect.go
+++ b/swagger/reflect.go
@@ -29,6 +29,13 @@ func inspect(t reflect.Type, jsonTag string) Property {
 		return p
 	}
 
+	if t.String() == "uuid.UUID" {
+		p.GoType = reflect.TypeOf("string")
+		p.Type = "string"
+		p.Format = "uuid"
+		return p
+	}
+
 	switch p.GoType.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint8, reflect.Uint16, reflect.Uint32:
 		p.Type = "integer"

--- a/util_test.go
+++ b/util_test.go
@@ -17,7 +17,7 @@ package swag_test
 import (
 	"testing"
 
-	"github.com/frednomoon/swag"
+	"github.com/music-tribe/swag"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/util_test.go
+++ b/util_test.go
@@ -17,7 +17,7 @@ package swag_test
 import (
 	"testing"
 
-	"github.com/savaki/swag"
+	"github.com/frednomoon/swag"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
 - Original package lacks handlers for `time.Time`, `json.RawMessage`, `*bool` as well as `uuid.UUID` types. These are now handled correctly for the documentation to be generated.

 - The package now will document struct examples given in the tags.