### PR TITLE
add custom unmarshaljson func for security requirement

### DIFF
--- a/swagger/endpoint.go
+++ b/swagger/endpoint.go
@@ -86,3 +86,17 @@ func (s *SecurityRequirement) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(s.Requirements)
 }
+
+func (s *SecurityRequirement) UnmarshalJSON(d []byte) error {
+	aux := make([]map[string][]string, 0)
+
+	if err := json.Unmarshal(d, &aux); err != nil {
+		return err
+	}
+
+	for _, v := range aux {
+		s.Requirements = append(s.Requirements, v)
+	}
+
+	return nil
+}


### PR DESCRIPTION
the dude who implemented custom json marshalling of swagger security didnt add the unmarshalling part, so our gateway threw an error every time it got service swagger jsons as it couldnt unmarshal to swagger.API properly