### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/MT-MCLOUD/1554b999-687d-4215-88e3-a70a9a374323/71d2d006-cee8-4b4f-88cc-4f4b3d2b31f9/_apis/work/boardbadge/33f0e0b8-6d6d-483e-ad9f-64cda63032d8)](https://dev.azure.com/MT-MCLOUD/1554b999-687d-4215-88e3-a70a9a374323/_boards/board/t/71d2d006-cee8-4b4f-88cc-4f4b3d2b31f9/Microsoft.RequirementCategory)
 
 
 # swag


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/MT-MCLOUD/1554b999-687d-4215-88e3-a70a9a374323/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.